### PR TITLE
Dualstack define not being passed ipv6 variable

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -41,6 +41,9 @@ class rhel::firewall (
 
   # Optional portknock resources to be created
   create_resources(rhel::firewall::portknock,$portknock)
+  Rhel::Firewall::Dualstack {
+    ipv6 => $ipv6,
+  }
 
 }
 


### PR DESCRIPTION
As I have ipv6 disabled on my box, I was getting errors when the dualstack define was trying to write rules.  I set the default here so that way anytime the dualstack define is used, no one needs to remember to add the ipv6 parameter.
